### PR TITLE
Actualizar enlace de compra a PayPal

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
             <p class="muted">PDF imprimible • 24 páginas • 3+</p>
             <strong class="price">S/ 12.00</strong>
             <div class="card-actions">
-              <a class="buy" href="#" target="_blank" rel="noopener">Comprar</a>
+              <a class="buy" href="https://www.paypal.com/donate/?hosted_button_id=H37DM4ACU3L88" target="_blank" rel="noopener">Comprar</a>
               <a class="try" href="#muestra-sol">Ver muestra</a>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- actualizar el botón Comprar del catálogo para que apunte al checkout alojado en PayPal

## Testing
- `curl -I https://www.paypal.com/donate/?hosted_button_id=H37DM4ACU3L88` *(falla: la red del entorno bloquea la conexión saliente)*

------
https://chatgpt.com/codex/tasks/task_e_68d97b998f90832ab6fdc0a9c872dd92